### PR TITLE
Add cross-link between README languages

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,5 @@
 # lemn**IQ** Libro de Recetas de Prompts
+Disponible en [inglés](README.md).
 
 *Un recetario práctico para crear prompts de ChatGPT que funcionan—sin jerga.*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lemn**IQ** Prompting Cookbook 📚✨
+Disponible en [Español](README.es.md).
 
 <p align="center">
   <img alt="lemnIQ cookbook badge" src="https://img.shields.io/badge/lemnIQ-cookbook-blueviolet?style=for-the-badge">


### PR DESCRIPTION
## Summary
- add top link from README to README.es
- add reciprocal link back to English version

## Testing
- `npm install -g markdownlint-cli` *(fails: EHOSTUNREACH)*
- `pip install codespell` *(fails: Cannot connect to proxy)*
- `pip install mkdocs-material` *(fails: Cannot connect to proxy)*